### PR TITLE
Add sample PCF component with custom visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # test-Site
-Test Site
+
+This repository contains examples and experiments. The `visual-pcf` folder contains a sample PowerApps Component Framework (PCF) control capable of rendering multiple chart types.

--- a/visual-pcf/ControlManifest.Input.xml
+++ b/visual-pcf/ControlManifest.Input.xml
@@ -1,0 +1,12 @@
+<manifest xmlns:pcf="http://schemas.microsoft.com/PowerApps/2020/ControlManifest">
+  <control namespace="Sample" constructor="VisualComponent" version="1.0.0" display-name-key="VisualComponent_Display_Name" description-key="VisualComponent_Desc">
+    <resources>
+      <code path="index.ts" order="1" />
+      <css path="style.css" order="2" />
+      <html path="index.html" order="3" />
+      <library name="ChartJS" version="3.9.1" path="https://cdn.jsdelivr.net/npm/chart.js" />
+    </resources>
+    <property name="dataSet" display-name-key="DataSet_Display_Name" description-key="DataSet_Desc" of-type="DataSet" usage="bound"/>
+    <property name="visualType" display-name-key="VisualType_Display_Name" description-key="VisualType_Desc" of-type="SingleLine.Text" usage="input" default-value="donut"/>
+  </control>
+</manifest>

--- a/visual-pcf/README.md
+++ b/visual-pcf/README.md
@@ -1,0 +1,12 @@
+# Visual PCF Component
+
+This directory contains a sample PowerApps Component Framework (PCF) control that renders different chart types using Chart.js. The control allows rendering the following visuals:
+
+- Donut chart
+- Stacked bar chart
+- Heatmap (matrix)
+- Line chart
+
+The control uses a dataset input for label/value pairs and an input property `visualType` to choose the desired visual.
+
+This is a skeleton implementation intended for demonstration purposes.

--- a/visual-pcf/index.html
+++ b/visual-pcf/index.html
@@ -1,0 +1,1 @@
+<div class="pcfChart"></div>

--- a/visual-pcf/index.ts
+++ b/visual-pcf/index.ts
@@ -1,0 +1,82 @@
+import {IInputs, IOutputs} from "./generated/ManifestTypes";
+
+export class VisualComponent implements ComponentFramework.StandardControl<IInputs, IOutputs> {
+    private container: HTMLDivElement;
+    private chart: any;
+    private visualType: string = "donut";
+
+    constructor() {}
+
+    public init(context: ComponentFramework.Context<IInputs>, notifyOutputChanged: () => void, state: ComponentFramework.Dictionary, container: HTMLDivElement) {
+        this.container = document.createElement("div");
+        container.appendChild(this.container);
+        this.visualType = context.parameters.visualType.raw || "donut";
+        this.renderChart(context);
+    }
+
+    private renderChart(context: ComponentFramework.Context<IInputs>) {
+        if (this.chart && typeof this.chart.destroy === "function") {
+            this.chart.destroy();
+        }
+        const canvas = document.createElement("canvas");
+        this.container.innerHTML = "";
+        this.container.appendChild(canvas);
+
+        const labels: string[] = [];
+        const data: number[] = [];
+        const dataset = context.parameters.dataSet;
+        dataset.sortedRecordIds.forEach(id => {
+            const record = dataset.records[id];
+            labels.push(record.getFormattedValue("label"));
+            data.push(parseFloat(record.getFormattedValue("value")) || 0);
+        });
+
+        const config = this.getChartConfig(this.visualType, labels, data);
+        // Chart is expected to be available globally via script tag
+        this.chart = new (window as any).Chart(canvas.getContext("2d"), config);
+    }
+
+    private getChartConfig(type: string, labels: string[], data: number[]): any {
+        switch (type) {
+            case "donut":
+                return {
+                    type: "doughnut",
+                    data: { labels, datasets: [{ data }] },
+                    options: { responsive: true }
+                };
+            case "stackedBar":
+                return {
+                    type: "bar",
+                    data: { labels, datasets: [{ data, backgroundColor: "#5b9bd5" }] },
+                    options: { scales: { x: { stacked: true }, y: { stacked: true } } }
+                };
+            case "heatmap":
+                return {
+                    type: "matrix",
+                    data: { datasets: [{ data: [] }] },
+                    options: {}
+                };
+            default:
+                return {
+                    type: "line",
+                    data: { labels, datasets: [{ data }] },
+                    options: {}
+                };
+        }
+    }
+
+    public updateView(context: ComponentFramework.Context<IInputs>): void {
+        const selectedType = context.parameters.visualType.raw || "donut";
+        if (selectedType !== this.visualType) {
+            this.visualType = selectedType;
+        }
+        this.renderChart(context);
+    }
+
+    public getOutputs(): IOutputs { return {}; }
+    public destroy(): void {
+        if (this.chart && typeof this.chart.destroy === "function") {
+            this.chart.destroy();
+        }
+    }
+}

--- a/visual-pcf/package.json
+++ b/visual-pcf/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "visual-pcf",
+  "version": "1.0.0",
+  "description": "Sample PCF component for custom visuals",
+  "scripts": {
+    "build": "pcf-scripts build"
+  },
+  "devDependencies": {
+    "pcf-scripts": "latest",
+    "typescript": "^4.0.0"
+  }
+}

--- a/visual-pcf/style.css
+++ b/visual-pcf/style.css
@@ -1,0 +1,4 @@
+.pcfChart {
+  width: 100%;
+  height: 100%;
+}

--- a/visual-pcf/tsconfig.json
+++ b/visual-pcf/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "lib": ["dom", "es2015"],
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true
+  },
+  "include": ["index.ts"]
+}


### PR DESCRIPTION
## Summary
- add a `visual-pcf` folder containing a skeleton PowerApps Component Framework component
- enable rendering donut, stacked bar, heatmap and line charts with Chart.js
- document the new component in `README.md`

## Testing
- `node -v`
