### PR TITLE
Add sample dataset for PCF component

### DIFF
--- a/visual-pcf/README.md
+++ b/visual-pcf/README.md
@@ -7,6 +7,6 @@ This directory contains a sample PowerApps Component Framework (PCF) control tha
 - Heatmap (matrix)
 - Line chart
 
-The control uses a dataset input for label/value pairs and an input property `visualType` to choose the desired visual.
+The control uses a dataset input for `label`/`value` pairs and an input property `visualType` to choose the desired visual. A small example dataset is provided in [`sample-data.csv`](./sample-data.csv) to illustrate the expected column names.
 
 This is a skeleton implementation intended for demonstration purposes.

--- a/visual-pcf/sample-data.csv
+++ b/visual-pcf/sample-data.csv
@@ -1,0 +1,4 @@
+label,value
+A,10
+B,20
+C,30


### PR DESCRIPTION
## Summary
- add a sample dataset file showing `label` and `value` columns
- mention the dataset in the PCF README so users know how to structure their data

## Testing
- `npm run build` *(fails: `pcf-scripts` not found)*