### PR TITLE
Load matrix plugin for PCF chart

### DIFF
--- a/visual-pcf/ControlManifest.Input.xml
+++ b/visual-pcf/ControlManifest.Input.xml
@@ -5,6 +5,8 @@
       <css path="style.css" order="2" />
       <html path="index.html" order="3" />
       <library name="ChartJS" version="3.9.1" path="https://cdn.jsdelivr.net/npm/chart.js" />
+      <!-- Plugin providing the matrix chart type -->
+      <library name="ChartJSMatrix" version="1.1.0" path="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@1.1.0/dist/chartjs-chart-matrix.min.js" />
     </resources>
     <property name="dataSet" display-name-key="DataSet_Display_Name" description-key="DataSet_Desc" of-type="DataSet" usage="bound"/>
     <property name="visualType" display-name-key="VisualType_Display_Name" description-key="VisualType_Desc" of-type="SingleLine.Text" usage="input" default-value="donut"/>

--- a/visual-pcf/index.ts
+++ b/visual-pcf/index.ts
@@ -1,4 +1,6 @@
 import {IInputs, IOutputs} from "./generated/ManifestTypes";
+// Ensure the matrix chart plugin registers with Chart.js during build
+import "chartjs-chart-matrix";
 
 export class VisualComponent implements ComponentFramework.StandardControl<IInputs, IOutputs> {
     private container: HTMLDivElement;

--- a/visual-pcf/package.json
+++ b/visual-pcf/package.json
@@ -5,6 +5,9 @@
   "scripts": {
     "build": "pcf-scripts build"
   },
+  "dependencies": {
+    "chartjs-chart-matrix": "^1.1.0"
+  },
   "devDependencies": {
     "pcf-scripts": "latest",
     "typescript": "^4.0.0"


### PR DESCRIPTION
## Summary
- enable matrix chart type by including `chartjs-chart-matrix` plugin
- add plugin dependency and import during build

## Testing
- `npm run build` *(fails: pcf-scripts not found)*