### PR TITLE
Add dataset structure explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # test-Site
 
 This repository contains examples and experiments. The `visual-pcf` folder contains a sample PowerApps Component Framework (PCF) control capable of rendering multiple chart types.
+
+
+Each dataset record must include a `label` field (string) and a `value` field (number). For example:
+
+```json
+[
+  { "label": "Category A", "value": 10 },
+  { "label": "Category B", "value": 25 }
+]
+```
+

--- a/visual-pcf/README.md
+++ b/visual-pcf/README.md
@@ -9,4 +9,15 @@ This directory contains a sample PowerApps Component Framework (PCF) control tha
 
 The control uses a dataset input for label/value pairs and an input property `visualType` to choose the desired visual.
 
+
+Each dataset record must include a `label` field (string) and a `value` field (number). For example:
+
+```json
+[
+  { "label": "Category A", "value": 10 },
+  { "label": "Category B", "value": 25 }
+]
+```
+
 This is a skeleton implementation intended for demonstration purposes.
+


### PR DESCRIPTION
## Summary
- document label/value dataset structure in the root README
- document label/value dataset structure in `visual-pcf/README.md`

## Testing
- `npm test` *(fails: could not find package.json)*